### PR TITLE
reduce re-computation

### DIFF
--- a/snack/default.nix
+++ b/snack/default.nix
@@ -17,14 +17,14 @@ let
   # that file only)
   singleOut = base: file:
     let
+      basePrefix = (builtins.toString base) + "/";
       pred = file: path: type:
         let
-          topLevel = (builtins.toString base) + "/";
-          actual = (pkgs.lib.strings.removePrefix topLevel path);
+          actual = (pkgs.lib.strings.removePrefix basePrefix path);
           expected = file;
-      in
-        (expected == actual) ||
-        (type == "directory" && (pkgs.lib.strings.hasPrefix actual expected));
+        in
+          (expected == actual) ||
+          (type == "directory" && (pkgs.lib.strings.hasPrefix actual expected));
       mod = fileToModule file;
 
     in pkgs.stdenv.mkDerivation {


### PR DESCRIPTION
Nix is not smart enough to promote calculated thunks to constants
between function invocations