### PR TITLE
Refactor snack.nix

### DIFF
--- a/bin/snack
+++ b/bin/snack
@@ -64,7 +64,7 @@ fi
 
 case $COMMAND in
   build)
-    "$NIX_BUILD" --no-out-link -A build "$SNACK_NIX"
+    "$NIX_BUILD" --no-out-link --show-trace -A build "$SNACK_NIX"
     ;;
   ghci)
     res=$("$NIX_BUILD" --no-out-link -A ghci "$SNACK_NIX")

--- a/bin/snack
+++ b/bin/snack
@@ -3,8 +3,10 @@ set -euo pipefail
 
 ## Defaults
 
+NIXPKGS=
 NIX_BUILD=nix-build
-SNACK_NIX=snack.nix
+SNACK_NIX="./snack.nix"
+WRAPPER_NIX=
 COMMAND=
 
 ## Functions
@@ -21,6 +23,12 @@ Snack is a Haskell build tool
 
 Options:
   -f | --snack-nix <PATH>: sets the path ot the "snack.nix" file. Default: "./snack.nix"
+  -w | --wrapper-nix <PATH>: sets the path ot the nix wrapper file. This file
+        should take at least one argument, "snackNix", which is the path to the
+        "snack.nix".
+  -n | --nixpkgs <PATH>: use the path to import nixpkgs. The expression should
+        take no arguments and evaluate to a set containing at least
+        "snack-lib".
   -h | --help: Shows this help
 
 Commands:
@@ -38,6 +46,16 @@ while [[ $# -gt 0 ]]; do
   case $key in
     -f | --snack-nix)
       SNACK_NIX="$2"
+      shift
+      shift
+      ;;
+    -w | --wrapper-nix)
+      WRAPPER_NIX="$2"
+      shift
+      shift
+      ;;
+    -n | --nixpkgs)
+      NIXPKGS="$2"
       shift
       shift
       ;;
@@ -62,16 +80,31 @@ if [[ -z "$COMMAND" ]]; then
   exit 1
 fi
 
+if [[ -z "$WRAPPER_NIX" ]]; then
+  log_error "missing <wrapper>\n"
+  show_usage
+  exit 1
+fi
+
+call_snack() {
+  "$NIX_BUILD" \
+    --no-out-link \
+    -A $1 \
+    "$WRAPPER_NIX" \
+    --arg snackNix "$SNACK_NIX" \
+    --arg nixpkgs "$NIXPKGS"
+}
+
 case $COMMAND in
   build)
-    "$NIX_BUILD" --no-out-link --show-trace -A build "$SNACK_NIX"
+    call_snack build
     ;;
   ghci)
-    res=$("$NIX_BUILD" --no-out-link -A ghci "$SNACK_NIX")
+    res=$(call_snack ghci)
     "$res"
     ;;
   run)
-    res=$("$NIX_BUILD" --no-out-link -A build "$SNACK_NIX")
+    res=$(call_snack build)
     "$res/out"
     ;;
 esac

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -3,7 +3,7 @@ _: pkgs: {
   snack-exe = pkgs.writeScriptBin
     "snack"
     (builtins.replaceStrings
-      ["NIX_BUILD=nix-build"]
-      ["NIX_BUILD=${pkgs.nix}/bin/nix-build"]
+      ["NIX_BUILD=nix-build"  "WRAPPER_NIX="]
+      ["NIX_BUILD=${pkgs.nix}/bin/nix-build"  "WRAPPER_NIX=${../snack-lib/wrapper.nix}"]
       (builtins.readFile ../bin/snack));
 }

--- a/script/test
+++ b/script/test
@@ -33,6 +33,8 @@ END_HEREDOC
 
 export -f capture_io
 
+export SNACK="snack -n $(readlink -f ./nix)"
+
 fail() {
   echo "ERROR: $*"
   exit 1

--- a/snack-lib/default.nix
+++ b/snack-lib/default.nix
@@ -23,7 +23,7 @@ let
     let
       ghcOptsArgs = lib.strings.escapeShellArgs ghcOpts;
       objectName = modSpec.moduleName;
-      builtDeps = map (buildModule ghc ghcOpts) modSpec.moduleDependencies;
+      builtDeps = map (buildModule ghc ghcOpts) modSpec.moduleImports;
       depsDirs = map (x: x + "/") builtDeps;
       base = modSpec.moduleBase;
       makeSymtree =
@@ -113,7 +113,7 @@ let
                 "${buildModule ghc ghcOpts elem}/${objectName elem}";
               };
         in
-          lib.lists.foldl f attrs1 mod.moduleDependencies;
+          lib.lists.foldl f attrs1 mod.moduleImports;
     in go mod0 {};
 
   # TODO: it's sad that we pass ghcWithDeps + dependencies
@@ -142,7 +142,7 @@ let
     lib.lists.concatLists
     (
     [ modSpec.moduleDirectories ]
-    ++ (lib.lists.concatMap allModuleDirectories modSpec.moduleDependencies)
+    ++ (lib.lists.concatMap allModuleDirectories modSpec.moduleImports)
     );
 
   # Write a new ghci executable that loads all the modules defined in the

--- a/snack-lib/files.nix
+++ b/snack-lib/files.nix
@@ -39,7 +39,6 @@ rec {
       '';
     };
 
-
   doesFileExist = base: filename:
     lib.lists.elem filename (listFilesInDir base);
 

--- a/snack-lib/module-spec.nix
+++ b/snack-lib/module-spec.nix
@@ -7,10 +7,13 @@
 with (callPackage ./modules.nix { inherit singleOut; });
 
 rec {
-  makeModuleSpec = modName: deps: isMain: modFiles: modDirs: modBase:
+  makeModuleSpec = modName: modImports: isMain: modFiles: modDirs: modBase:
     { moduleName = modName;
       moduleIsMain = isMain;
-      moduleDependencies = deps;
+
+      # local module imports, i.e. not part of an external dependency
+      moduleImports = modImports;
+
       moduleFiles = modFiles;
       moduleDirectories = modDirs;
       moduleBase = modBase;
@@ -24,7 +27,7 @@ rec {
         makeModuleSpec
           modName
           (map (f false)
-            (listModuleDependencies baseByModuleName modName)
+            (listModuleImports baseByModuleName modName)
           )
           isMain
           (filesByModuleName modName)
@@ -35,6 +38,6 @@ rec {
   # Returns a list of all modules in the module spec graph
   flattenModuleSpec = modSpec:
     [ modSpec ] ++
-      ( lib.lists.concatMap flattenModuleSpec modSpec.moduleDependencies );
+      ( lib.lists.concatMap flattenModuleSpec modSpec.moduleImports );
 
 }

--- a/snack-lib/module-spec.nix
+++ b/snack-lib/module-spec.nix
@@ -1,0 +1,40 @@
+# Functions related to module specs
+{ lib
+, callPackage
+, singleOut
+}:
+
+with (callPackage ./modules.nix { inherit singleOut; });
+
+rec {
+  makeModuleSpec = modName: deps: isMain: modFiles: modDirs: modBase:
+    { moduleName = modName;
+      moduleIsMain = isMain;
+      moduleDependencies = deps;
+      moduleFiles = modFiles;
+      moduleDirectories = modDirs;
+      moduleBase = modBase;
+    };
+
+  # Create a module spec by following the dependencies. This assumes that the
+  # specified module is a "Main" module.
+  makeModuleSpecRec = baseByModuleName: filesByModuleName: dirsByModuleName:
+    lib.fix
+      (f: isMain: modName:
+        makeModuleSpec
+          modName
+          (map (f false)
+            (listModuleDependencies baseByModuleName modName)
+          )
+          isMain
+          (filesByModuleName modName)
+          (dirsByModuleName modName)
+          (baseByModuleName modName)
+      ) true;
+
+  # Returns a list of all modules in the module spec graph
+  flattenModuleSpec = modSpec:
+    [ modSpec ] ++
+      ( lib.lists.concatMap flattenModuleSpec modSpec.moduleDependencies );
+
+}

--- a/snack-lib/module-spec.nix
+++ b/snack-lib/module-spec.nix
@@ -42,7 +42,7 @@ rec {
         makeModuleSpec
           modName
           (map (f false)
-            (listModuleImports baseByModuleName modName)
+            (lib.lists.filter (mn: baseByModuleName mn != null) (listModuleImports baseByModuleName modName))
           )
           isMain
           (filesByModuleName modName)

--- a/snack-lib/module-spec.nix
+++ b/snack-lib/module-spec.nix
@@ -7,7 +7,15 @@
 with (callPackage ./modules.nix { inherit singleOut; });
 
 rec {
-  makeModuleSpec = modName: modImports: isMain: modFiles: modDirs: modBase:
+    makeModuleSpec =
+    modName:
+    modImports:
+    isMain:
+    modFiles:
+    modDirs:
+    modBase:
+    modDeps:
+    modGhcOpts:
     { moduleName = modName;
       moduleIsMain = isMain;
 
@@ -17,11 +25,18 @@ rec {
       moduleFiles = modFiles;
       moduleDirectories = modDirs;
       moduleBase = modBase;
+      moduleDependencies = modDeps;
+      moduleGhcOpts = modGhcOpts;
     };
 
   # Create a module spec by following the dependencies. This assumes that the
   # specified module is a "Main" module.
-  makeModuleSpecRec = baseByModuleName: filesByModuleName: dirsByModuleName:
+    makeModuleSpecRec =
+    baseByModuleName:
+    filesByModuleName:
+    dirsByModuleName:
+    depsByModuleName:
+    ghcOptsByModuleName:
     lib.fix
       (f: isMain: modName:
         makeModuleSpec
@@ -33,6 +48,8 @@ rec {
           (filesByModuleName modName)
           (dirsByModuleName modName)
           (baseByModuleName modName)
+          (depsByModuleName modName)
+          (ghcOptsByModuleName modName)
       ) true;
 
   # Returns a list of all modules in the module spec graph

--- a/snack-lib/modules.nix
+++ b/snack-lib/modules.nix
@@ -31,11 +31,11 @@ rec {
 
   # Generate a list of haskell module names needed by the haskell file,
   # excluding modules that are not present in this project/base
-  listModuleDependencies = baseByModuleName: modName:
+  listModuleImports = baseByModuleName: modName:
     lib.filter
       (doesModuleExist baseByModuleName)
       (builtins.fromJSON
-        (builtins.readFile (listAllModuleDependenciesJSON (baseByModuleName modName) modName))
+        (builtins.readFile (listAllModuleImportsJSON (baseByModuleName modName) modName))
       );
 
   listModulesInDir = dir: map fileToModule (listFilesInDir dir);
@@ -47,7 +47,7 @@ rec {
 
   # Lists all module dependencies, not limited to modules existing in this
   # project
-  listAllModuleDependenciesJSON = base: modName:
+  listAllModuleImportsJSON = base: modName:
     let
       importParser = runCommand "import-parser"
         { buildInputs =

--- a/snack-lib/modules.nix
+++ b/snack-lib/modules.nix
@@ -29,21 +29,16 @@ rec {
   singleOutModulePath = base: mod:
     "${singleOut base (moduleToFile mod)}/${moduleToFile mod}";
 
-  # Generate a list of haskell module names needed by the haskell file,
-  # excluding modules that are not present in this project/base
+  # Generate a list of haskell module names needed by the haskell file
   listModuleImports = baseByModuleName: modName:
-    lib.filter
-      (doesModuleExist baseByModuleName)
-      (builtins.fromJSON
-        (builtins.readFile (listAllModuleImportsJSON (baseByModuleName modName) modName))
-      );
+    builtins.fromJSON
+     (builtins.readFile (listAllModuleImportsJSON (baseByModuleName modName) modName))
+    ;
 
   listModulesInDir = dir: map fileToModule (listFilesInDir dir);
 
-
   doesModuleExist = baseByModuleName: modName:
     doesFileExist (baseByModuleName modName) (moduleToFile modName);
-
 
   # Lists all module dependencies, not limited to modules existing in this
   # project

--- a/snack-lib/modules.nix
+++ b/snack-lib/modules.nix
@@ -1,7 +1,12 @@
 # module related operations
 { lib
+, callPackage
+, runCommand
 , singleOut
+, haskellPackages
 }:
+
+with (callPackage ./files.nix {});
 
 rec {
   # Turns a module name to a file
@@ -23,4 +28,33 @@ rec {
   # Singles out a given module (by module name) (path to module file)
   singleOutModulePath = base: mod:
     "${singleOut base (moduleToFile mod)}/${moduleToFile mod}";
+
+  # Generate a list of haskell module names needed by the haskell file,
+  # excluding modules that are not present in this project/base
+  listModuleDependencies = baseByModuleName: modName:
+    lib.filter
+      (doesModuleExist baseByModuleName)
+      (builtins.fromJSON
+        (builtins.readFile (listAllModuleDependenciesJSON (baseByModuleName modName) modName))
+      );
+
+  listModulesInDir = dir: map fileToModule (listFilesInDir dir);
+
+
+  doesModuleExist = baseByModuleName: modName:
+    doesFileExist (baseByModuleName modName) (moduleToFile modName);
+
+
+  # Lists all module dependencies, not limited to modules existing in this
+  # project
+  listAllModuleDependenciesJSON = base: modName:
+    let
+      importParser = runCommand "import-parser"
+        { buildInputs =
+          [ (haskellPackages.ghcWithPackages
+            (ps: [ ps.haskell-src-exts ]))
+          ];
+        } "ghc ${./Imports.hs} -o $out" ;
+    in runCommand "dependencies-json" {}
+         "${importParser} ${singleOutModulePath base modName} > $out";
 }

--- a/snack-lib/package-spec.nix
+++ b/snack-lib/package-spec.nix
@@ -43,10 +43,17 @@ rec {
     (pkgSpec: pkgSpec.packageDependencies)
     (flattenPackages topPkgSpec);
 
+  # TODO: nub
+  allTransitiveGhcOpts = topPkgSpec:
+    lib.lists.concatMap
+    (pkgSpec: pkgSpec.packageGhcOpts)
+    (flattenPackages topPkgSpec);
 
-  # Returns the first package spec that contains a module with given name. If
-  # none is found, returns the supplied default value.
-  pkgSpecByModuleName = pkgs: def: modName:
+
+  # Traverses all transitive packages and returns the first package spec that
+  # contains a module with given name. If none is found, returns the supplied
+  # default value.
+  pkgSpecByModuleName = topPkgSpec: def: modName:
     ( lib.findFirst
         (pkgSpec:
           lib.lists.elem
@@ -54,6 +61,6 @@ rec {
             (listModulesInDir pkgSpec.packageBase)
         )
         def
-        pkgs
+        (flattenPackages topPkgSpec)
     );
 }

--- a/snack-lib/package-spec.nix
+++ b/snack-lib/package-spec.nix
@@ -1,0 +1,59 @@
+{ lib
+, singleOut
+, callPackage
+}:
+
+with (callPackage ./modules.nix { inherit singleOut; });
+
+rec {
+
+  mkPackageSpec =
+  packageDescr@
+    { src
+    , main ? null
+    , ghcOpts ? []
+    , dependencies ? []
+    , extra-files ? []
+    , extra-directories ? []
+    , packages ? lib.filter (x: builtins.typeOf x != "string") dependencies
+    }:
+    { packageMain = main;
+      packageBase = src;
+      packageGhcOpts = ghcOpts;
+      packageDependencies = lib.filter (x: builtins.typeOf x == "string") dependencies;
+
+      # TODO: merge extra files and extra dirs together
+      packageExtraFiles =
+          if builtins.isList extra-files
+          then (_x: extra-files)
+          else extra-files;
+      packageExtraDirectories =
+            if builtins.isList extra-directories
+            then (_x: extra-directories)
+            else extra-directories;
+      packagePackages = map mkPackageSpec packages;
+    };
+
+  flattenPackages = topPkgSpec:
+    [topPkgSpec] ++ lib.lists.concatMap (flattenPackages) topPkgSpec.packagePackages;
+
+  # TODO: nub
+  allTransitiveDeps = topPkgSpec:
+    lib.lists.concatMap
+    (pkgSpec: pkgSpec.packageDependencies)
+    (flattenPackages topPkgSpec);
+
+
+  # Returns the first package spec that contains a module with given name. If
+  # none is found, returns the supplied default value.
+  pkgSpecByModuleName = pkgs: def: modName:
+    ( lib.findFirst
+        (pkgSpec:
+          lib.lists.elem
+            modName
+            (listModulesInDir pkgSpec.packageBase)
+        )
+        def
+        pkgs
+    );
+}

--- a/snack-lib/wrapper.nix
+++ b/snack-lib/wrapper.nix
@@ -7,8 +7,9 @@
       then import <nixpkgs> {}
       else import nixpkgs {};
     snack = pkgs.snack-lib;
+    snackDef = import snackNix;
   in
 {
-  build = (snack.executable (import snackNix)).build;
-  ghci = (snack.executable (import snackNix)).ghci;
+  build = (snack.executable snackDef).build;
+  ghci = (snack.executable snackDef).ghci;
 }

--- a/snack-lib/wrapper.nix
+++ b/snack-lib/wrapper.nix
@@ -1,0 +1,14 @@
+{ snackNix
+, nixpkgs ? null
+}:
+  let
+    pkgs =
+      if nixpkgs == null
+      then import <nixpkgs> {}
+      else import nixpkgs {};
+    snack = pkgs.snack-lib;
+  in
+{
+  build = (snack.executable (import snackNix)).build;
+  ghci = (snack.executable (import snackNix)).ghci;
+}

--- a/tests/library/snack.nix
+++ b/tests/library/snack.nix
@@ -3,7 +3,7 @@ let
   snack = pkgs.snack-lib;
   my-lib = snack.library
     { src = ./src;
-      #dependencies = [ "conduit" ];
+      dependencies = [ "conduit" ];
     };
 in
   snack.executable

--- a/tests/library/snack.nix
+++ b/tests/library/snack.nix
@@ -1,13 +1,10 @@
 let
-  pkgs = import ../../nix {};
-  snack = pkgs.snack-lib;
-  my-lib = snack.library
+  my-lib =
     { src = ./src;
       dependencies = [ "conduit" ];
     };
 in
-  snack.executable
-    { main = "Foo";
-      src = ./app;
-      dependencies = [ my-lib "conduit" ];
-    }
+  { main = "Foo";
+    src = ./app;
+    dependencies = [ my-lib "conduit" ];
+  }

--- a/tests/library/test
+++ b/tests/library/test
@@ -3,12 +3,12 @@
 
 set -euo pipefail
 
-snack build
-snack run | diff golden -
+$SNACK build
+$SNACK run | diff golden -
 
 TMP_FILE=$(mktemp)
 
-capture_io "$TMP_FILE" main | snack ghci
+capture_io "$TMP_FILE" main | $SNACK ghci
 
 diff golden $TMP_FILE
 rm $TMP_FILE

--- a/tests/packages/snack.nix
+++ b/tests/packages/snack.nix
@@ -1,9 +1,4 @@
-let
-  pkgs = import ../../nix {};
-  snack = pkgs.snack-lib;
-in
-  snack.executable
-    { main = "Foo";
-      src = ./src;
-      dependencies = ["conduit"];
-    }
+{ main = "Foo";
+  src = ./src;
+  dependencies = ["conduit"];
+}

--- a/tests/packages/test
+++ b/tests/packages/test
@@ -3,12 +3,12 @@
 
 set -euo pipefail
 
-snack build
-snack run | diff golden -
+$SNACK build
+$SNACK run | diff golden -
 
 TMP_FILE=$(mktemp)
 
-capture_io "$TMP_FILE" main | snack ghci
+capture_io "$TMP_FILE" main | $SNACK ghci
 
 diff golden $TMP_FILE
 rm $TMP_FILE

--- a/tests/template-haskell-2/code/snack.nix
+++ b/tests/template-haskell-2/code/snack.nix
@@ -1,11 +1,6 @@
-let
-  pkgs = import ../../../nix {};
-  snack = pkgs.snack-lib;
-in
-  snack.executable
-    { main = "Main";
-      src = ./.;
-      dependencies = ["file-embed"];
-      extra-directories =
-        (modName: if modName == "Main" then [ ../. ] else []);
-    }
+{ main = "Main";
+  src = ./.;
+  dependencies = ["file-embed"];
+  extra-directories =
+    (modName: if modName == "Main" then [ ../. ] else []);
+}

--- a/tests/template-haskell-2/test
+++ b/tests/template-haskell-2/test
@@ -3,12 +3,12 @@
 
 set -euo pipefail
 
-snack build -f code/snack.nix
-snack run -f code/snack.nix | diff golden -
+$SNACK build -f code/snack.nix
+$SNACK run -f code/snack.nix | diff golden -
 
 TMP_FILE=$(mktemp)
 
-capture_io "$TMP_FILE" main | snack -f code/snack.nix ghci
+capture_io "$TMP_FILE" main | $SNACK -f code/snack.nix ghci
 
 diff golden $TMP_FILE
 rm $TMP_FILE

--- a/tests/template-haskell-3/snack.nix
+++ b/tests/template-haskell-3/snack.nix
@@ -1,11 +1,6 @@
-let
-  pkgs = import ../../nix {};
-  snack = pkgs.snack-lib;
-in
-  snack.executable
-    { main = "Main";
-      src = ./.;
-      dependencies = ["file-embed"];
-      extra-files =
-        (modName: if modName == "Main" then [ "assets/foo.txt" ] else []);
-    }
+{ main = "Main";
+  src = ./.;
+  dependencies = ["file-embed"];
+  extra-files =
+    (modName: if modName == "Main" then [ "assets/foo.txt" ] else []);
+}

--- a/tests/template-haskell-3/test
+++ b/tests/template-haskell-3/test
@@ -3,12 +3,12 @@
 
 set -euo pipefail
 
-snack build
-snack run | diff golden -
+$SNACK build
+$SNACK run | diff golden -
 
 TMP_FILE=$(mktemp)
 
-capture_io "$TMP_FILE" main | snack ghci
+capture_io "$TMP_FILE" main | $SNACK ghci
 
 diff golden $TMP_FILE
 rm $TMP_FILE

--- a/tests/template-haskell-4/snack.nix
+++ b/tests/template-haskell-4/snack.nix
@@ -1,11 +1,6 @@
-let
-  pkgs = import ../../nix {};
-  snack = pkgs.snack-lib;
-in
-  snack.executable
-    { main = "Main";
-      src = ./src;
-      dependencies = ["file-embed"];
-      extra-directories =
-        (modName: if modName == "Main" then [ ./assets ] else []);
-    }
+{ main = "Main";
+  src = ./src;
+  dependencies = ["file-embed"];
+  extra-directories =
+    (modName: if modName == "Main" then [ ./assets ] else []);
+}

--- a/tests/template-haskell-4/test
+++ b/tests/template-haskell-4/test
@@ -3,12 +3,12 @@
 
 set -euo pipefail
 
-snack build
-snack run | diff golden -
+$SNACK build
+$SNACK run | diff golden -
 
 TMP_FILE=$(mktemp)
 
-capture_io "$TMP_FILE" main | snack ghci
+capture_io "$TMP_FILE" main | $SNACK ghci
 
 diff golden $TMP_FILE
 rm $TMP_FILE

--- a/tests/template-haskell/snack.nix
+++ b/tests/template-haskell/snack.nix
@@ -1,11 +1,6 @@
-let
-  pkgs = import ../../nix {};
-  snack = pkgs.snack-lib;
-in
-  snack.executable
-    { main = "Main";
-      src = ./.;
-      dependencies = ["file-embed"];
-      extra-files =
-        (modName: if modName == "Main" then [ "foo.txt" ] else []);
-    }
+{ main = "Main";
+  src = ./.;
+  dependencies = ["file-embed"];
+  extra-files =
+    (modName: if modName == "Main" then [ "foo.txt" ] else []);
+}

--- a/tests/template-haskell/test
+++ b/tests/template-haskell/test
@@ -3,12 +3,12 @@
 
 set -euo pipefail
 
-snack build
-snack run | diff golden -
+$SNACK build
+$SNACK run | diff golden -
 
 TMP_FILE=$(mktemp)
 
-capture_io "$TMP_FILE" main | snack ghci
+capture_io "$TMP_FILE" main | $SNACK ghci
 
 diff golden $TMP_FILE
 rm $TMP_FILE


### PR DESCRIPTION
This simplifies the `snack.nix` quite a lot; now it's just an attr set (next step: YAML). This makes the `snack` executable a bit more complex, I'd like to simplify that as a next step. @zimbatm thoughts on this?