### PR TITLE
Add dhall support

### DIFF
--- a/snack-lib/files.nix
+++ b/snack-lib/files.nix
@@ -50,6 +50,12 @@ rec {
   doesFileExist = base: filename:
     lib.lists.elem filename (listFilesInDir base);
 
+  fileExtension = fp:
+    let
+      exts = lib.splitString "." (builtins.baseNameOf fp);
+    in if lib.length exts == 0 then null else lib.last exts;
+
+
   listFilesInDir = dir:
   let
     go = dir: dirName:

--- a/tests/readme/package.dhall
+++ b/tests/readme/package.dhall
@@ -1,0 +1,16 @@
+{ name = "snack-readme"
+
+, dependencies =
+    [ "lens", "wreq" ]
+
+, library =
+    { source-dirs = "./src" }
+
+, executable =
+    { main = "Main.hs"
+    , source-dirs = "./app"
+    , dependencies = [ "snack-readme" ]
+    }
+
+, default-extensions = [ "OverloadedStrings" ]
+}

--- a/tests/readme/test
+++ b/tests/readme/test
@@ -11,3 +11,4 @@ test() {
 SNACK="snack" test
 SNACK="snack -s ./snack.nix" test
 SNACK="snack --package-yaml ./package.yaml" test
+SNACK="snack --package-yaml ./package.dhall" test


### PR DESCRIPTION
Fixes #51 

@philderbeast this adds support for reading `package.dhall` files (I still need to update the command line arguments and the documentation, but the meat is there). However I doubt that this is going to work if _other_ files are imported from `package.dhall`, like this:

``` dhall
{ foo = ./some/path.dhall }
```

I'm not sure how this can be done in a way that works in the sandbox (dhall-nix suffers from the same problem). @Gabriel439 do you have thoughts on this? 