### PR TITLE
Fix dependency propagation and add mkPackage

### DIFF
--- a/snack-lib/build.nix
+++ b/snack-lib/build.nix
@@ -69,7 +69,8 @@ rec {
 
   buildModule = ghcWith: modSpec:
     let
-      ghc = ghcWith modSpec.moduleDependencies;
+      ghc = ghcWith deps;
+      deps = allTransitiveDeps [modSpec];
       exts = modSpec.moduleExtensions;
       ghcOpts = modSpec.moduleGhcOpts ++ (map (x: "-X${x}") exts);
       ghcOptsArgs = lib.strings.escapeShellArgs ghcOpts;


### PR DESCRIPTION
This fixes problems with missing dependencies during builds. It also adds a `mkPackage` wrapper around `inferSnackBuild` that directly takes a nix expression. This fixes #70 and is a step towards #68.