### PR TITLE
Support -main-is to change namespace

### DIFF
--- a/snack-lib/build.nix
+++ b/snack-lib/build.nix
@@ -18,11 +18,11 @@ rec {
   # Returns an attribute set where the keys are all the built module names and
   # the values are the paths to the object files.
   # mainModSpec: a "main" module
-  buildMain = ghcWith: mainModSpec:
+  buildMain = ghcWith: mainModSpec: mainModName:
     buildModulesRec ghcWith
       # XXX: the main modules need special handling regarding the object name
       { "${mainModSpec.moduleName}" =
-        "${buildModule ghcWith mainModSpec}/Main.o";}
+        "${buildModule ghcWith mainModSpec}/${mainModName}.o";}
       mainModSpec.moduleImports;
 
   # returns a attrset where the keys are the module names and the values are
@@ -34,9 +34,10 @@ rec {
       { ghcWith
       , moduleSpec # The module to build
       , name # The name to give the executable
+      , mainModName
       }:
     let
-      objAttrs = buildMain ghcWith moduleSpec;
+      objAttrs = buildMain ghcWith moduleSpec mainModName;
       objList = lib.attrsets.mapAttrsToList (x: y: y) objAttrs;
       deps = allTransitiveDeps [moduleSpec];
       ghc = ghcWith deps;

--- a/snack-lib/default.nix
+++ b/snack-lib/default.nix
@@ -46,7 +46,8 @@ with rec
     let
       moduleSpec = executableMainModSpec pkgSpec;
       name = pkgSpec.packageName;
-      drv = linkMainModule { inherit moduleSpec name ghcWith; };
+      mainModName = pkgSpec.packageMainModule;
+      drv = linkMainModule { inherit moduleSpec name ghcWith mainModName; };
     in
       { out = drv.out;
         exe_path = "${drv.out}/${drv.relExePath}";

--- a/snack-lib/package-spec.nix
+++ b/snack-lib/package-spec.nix
@@ -11,6 +11,7 @@ rec {
     { src ? []
     , name ? null
     , main ? null
+    , mainModule ? "Main"
     , ghcOpts ? []
     , dependencies ? []
     , extensions ? []
@@ -29,11 +30,20 @@ rec {
     { packageIsExe = ! builtins.isNull main;
       packageName = pName;
       packageMain = main;
+      packageMainModule = mainModule;
       packageSourceDirs =
         if builtins.isList src
         then src
         else [src];
-      packageGhcOpts = ghcOpts;
+      packageGhcOpts = let
+        addition =
+          if mainModule == "Main"
+          then
+            []
+          else
+            ["-main-is" mainModule];
+        in
+          ghcOpts ++ addition;
       packageExtensions = extensions;
       packageDependencies = mkPerModuleAttr dependencies;
 

--- a/tests/main-is-different/Spec.hs
+++ b/tests/main-is-different/Spec.hs
@@ -1,0 +1,12 @@
+{-|
+Copyright:
+    © 2018 Nicolas Mattia
+-}
+module Spec
+    ( main
+    ) where
+
+import Numeric.Natural (Natural)
+
+main :: IO ()
+main = putStrLn "hello, test!"

--- a/tests/main-is-different/golden
+++ b/tests/main-is-different/golden
@@ -1,0 +1,1 @@
+hello, test!

--- a/tests/main-is-different/package.nix
+++ b/tests/main-is-different/package.nix
@@ -1,0 +1,4 @@
+{ main = "Spec";
+  mainModule = "Spec";
+  src = ./.;
+}

--- a/tests/main-is-different/test
+++ b/tests/main-is-different/test
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# vim: ft=sh sw=2 et
+
+set -euo pipefail
+
+test() {
+  $SNACK build
+  $SNACK run | diff golden -
+
+  TMP_FILE=$(mktemp)
+
+  capture_io "$TMP_FILE" main | $SNACK ghci
+
+  diff golden $TMP_FILE
+  rm $TMP_FILE
+}
+
+SNACK="snack --package-file ./package.nix" test


### PR DESCRIPTION
Fix https://github.com/nmattia/snack/issues/161 by supporting -main-is ghc flag.

This PR adds a variable `mainModule` in to detect main module name for this purpose.
